### PR TITLE
ZShaderToy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "zmidi"]
 	path = zmidi
 	url = https://github.com/fieldofview/pyZMIDI.git
+[submodule "zshadertoy"]
+	path = zshadertoy
+	url = https://github.com/fieldOfView/pyZShaderToy.git


### PR DESCRIPTION
Adds a node that displays a fullscreen pixelshader on the framebuffer of a Raspberry Pi. New shaders can be sent to the node over ZOCP. Should accept many pixel shader examples from http://glslsandbox.com

Based on https://github.com/benosteen/pyopengles
